### PR TITLE
fix for CentOS-6 init script to properly stop all processes

### DIFF
--- a/scripts/startscripts/centos_rhel/6/postomaat
+++ b/scripts/startscripts/centos_rhel/6/postomaat
@@ -17,7 +17,7 @@
 case "$1" in
   start)
         echo -n "Starting Postomaat Policy Daemon: "
-        daemon /usr/bin/postomaat
+        daemon /usr/bin/postomaat --pidfile=/var/run/postomaatd.pid
         RETVAL=$?
         echo
         ;;


### PR DESCRIPTION
same strategy as in fuglu

Note:
It's important not to use /var/run/postomaat.pid but a different file name
since /var/run/postomaat.pid is used internally in postomaat